### PR TITLE
Python3

### DIFF
--- a/qualysapi/connector.py
+++ b/qualysapi/connector.py
@@ -1,5 +1,4 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import (absolute_import, print_function, unicode_literals)
 __author__ = 'Parag Baxi <parag.baxi@gmail.com>'
 __copyright__ = 'Copyright 2013, Parag Baxi'
 __license__ = 'Apache License 2.0'
@@ -7,9 +6,10 @@ __license__ = 'Apache License 2.0'
 """ Module that contains classes for setting up connections to QualysGuard API
 and requesting data from it.
 """
+import sys
 import logging
 import time
-import urlparse
+from six.moves.urllib.parse import urlparse
 from collections import defaultdict
 
 import requests
@@ -23,6 +23,12 @@ import qualysapi.api_actions as api_actions
 # Setup module level logging.
 logging.basicConfig()
 logger = logging.getLogger(__name__)
+
+# Setup response-string handling for Python 2 and 3
+if sys.version_info < (3,):
+    text_type = str
+else:
+    text_type = bytes
 
 try:
     from lxml import etree
@@ -317,10 +323,11 @@ class QGConnector(api_actions.QGActions):
                 logger.debug(e)
                 pass
             # Response received.
-            response = str(request.content)
+            response = text_type(request.content).decode('utf-8')
             logger.debug('response text =\n%s' % (response))
             # Keep track of how many retries.
             retries += 1
+
             # Check for concurrent scans limit.
             if not ('<responseCode>INVALID_REQUEST</responseCode>' in response and \
                                 '<errorMessage>You have reached the maximum number of concurrent running scans' in response and \

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ __license__ = 'BSD-new'
 # Make pyflakes happy.
 __pkgname__ = None
 __version__ = None
-execfile('qualysapi/version.py')
+exec(open('qualysapi/version.py').read())
 
 # A utility function to read the README file into the long_description field.
 def read(fname):

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,7 @@ setup(name=__pkgname__,
       ],
       install_requires=[
           'requests',
+          'lxml',
+          'six'
       ],
      )


### PR DESCRIPTION
Just a few small changes to get it to work for me with both Python 3 and Python 2.

1. **setup.py**: replaced execfile() with a compatible alternative. The allows pip3 to build the package properly.
2. **setup.py**: added a couple of already-used module requirements.
3. **qualysapi/connector.py**: added compatible response-string handling, and compatible urlparse()
